### PR TITLE
Fix: unhard-code /usr/src when listing modules

### DIFF
--- a/occambsd.sh
+++ b/occambsd.sh
@@ -228,7 +228,7 @@ tail $work_dir/src.conf
 
 # MODULES
 
-ls /usr/src/sys/modules/ | cat > $work_dir/all_modules.txt
+ls ${src_dir}/sys/modules/ | cat > $work_dir/all_modules.txt
 echo ; echo All modules are listed in $work_dir/all_modules.txt
 
 # DO YOU WANNA BUILD A KERN CONF?

--- a/profile-arm64-minimum.txt
+++ b/profile-arm64-minimum.txt
@@ -6,4 +6,4 @@ cpu="ARM64"
 
 build_options="WITHOUT_AUTO_OBJ WITHOUT_UNIFIED_OBJDIR WITHOUT_INSTALLLIB WITHOUT_BOOT WITHOUT_LOADER_LUA WITHOUT_LOCALES WITHOUT_ZONEINFO WITHOUT_DYNAMICROOT WITHOUT_FP_LIBC WITHOUT_VI"
 
-kernel_includes="std.arm64 std.dev std.al std.allwinner std.altera std.amd std.arm std.broadcom std.cavium std.ec2 std.hyperv std.hisilicon std.imx std.marvell std.nvidia std.nxp std.qcom std.rockchip std.virt std.xilinx"
+kernel_includes="std.arm64 std.dev std.virt"


### PR DESCRIPTION
At MODULES, OccamBSD does `ls /usr/src/sys/modules/`, which should be `${src_dir}/sys/modules/` in case the user has specified `-s`.

Tested on ARM64