### PR TITLE
When updating work_dir (-O option), also update src_conf.

### DIFF
--- a/occambsd.sh
+++ b/occambsd.sh
@@ -584,7 +584,7 @@ if [ "$generate_jail" = "1" ] ; then
 
 	/usr/bin/time -h env MAKEOBJDIRPREFIX="$obj_dir" make -C "$src_dir" \
 	installworld SRCCONF="$src_conf" \
-	DESTDIR="${work_dir}/roow/" \
+	DESTDIR="${work_dir}/root/" \
 	NO_FSCHG=YES \
 		> "$log_dir/install-jail-world.log" 2>&1
 

--- a/occambsd.sh
+++ b/occambsd.sh
@@ -146,6 +146,7 @@ while getopts p:s:o:O:wWkKa:bGgP:zj9vzZ:S:imn opts ; do
 	O)
 		work_dir="$OPTARG"
   		kernconf_dir="$OPTARG"
+                src_conf="$work_dir/src.conf"
 		;;
 	w)
 		reuse_world=1


### PR DESCRIPTION
Before this change, the logic for the -O option changes the work_dir variable, but not the src_conf variable, which uses the value of work_dir. This change updates the src_conf to match.

Anyone who was not using the -O option and was using the default work_dir (/tmp/occambsd) would not see any trouble without this change.